### PR TITLE
Avoids unnecessary compile in docker build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,11 +31,15 @@ jobs:
       - run:
           name: Save WAR file
           command: |
-            mkdir -p ~/rideout
-            find . -type f -regex ".*/target/.*war" -exec cp {} ~/rideout/ \;
+            mkdir -p ~/project/rideout
+            find . -type f -regex ".*/target/.*war" -exec cp {} ~/project/rideout/ \;
           when: always
       - store_artifacts:
-          path: ~/rideout
+          path: ~/project/rideout
+      - persist_to_workspace:
+          root: .
+          paths:
+            - rideout
   docker_build:
     environment:
       IMAGE_NAME: solentio/rideout
@@ -43,12 +47,13 @@ jobs:
       - image: circleci/buildpack-deps:stretch
     steps:
       - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
+      - attach_workspace:
+          at: .
+      - setup_remote_docker
       - run:
           name: Build Docker Image
           command: |
-            docker build -t $IMAGE_NAME:$(echo ${CIRCLE_BRANCH} | tr '/' '_') .
+            docker build -t $IMAGE_NAME:$(echo ${CIRCLE_BRANCH} | tr '/' '_') -f Dockerfile.circleci .
       - run:
           name: Publish Docker Image to Docker Hub
           command: |

--- a/Dockerfile.circleci
+++ b/Dockerfile.circleci
@@ -1,0 +1,6 @@
+FROM tomcat:9-jre8-alpine
+RUN rm -r $CATALINA_HOME/webapps/ROOT
+COPY rideout/rideout-api.war $CATALINA_HOME/webapps/ROOT.war
+EXPOSE 8080
+
+HEALTHCHECK --interval=1m --timeout=3s CMD wget --quiet --tries=1 --spider http://localhost:8080/ || exit 1


### PR DESCRIPTION
* Saves WAR file compiled in the "build" stage to avoid having to
rebuild the project during the dockerbuild
* Creates a new Dockerfile for circleci only