### PR TITLE
Build docker image on all branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,11 +93,6 @@ workflows:
       - docker_build:
           requires:
             - build
-          filters:
-            branches:
-              only:
-                - master
-                - dev
       - kube_deploy:
           requires:
             - docker_build


### PR DESCRIPTION
Now that we are using CircleCI to build docker images, and not DockerHub - we should now be able to build docker images for all branches without bogging anything down. Docker builds only take 30 seconds with the optimised dockerfile.circleci 
